### PR TITLE
Add support for comment special form

### DIFF
--- a/crates/fennel-parser/src/ast.rs
+++ b/crates/fennel-parser/src/ast.rs
@@ -1218,4 +1218,11 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn comment_form() {
+        let text = "(comment (fn f [] some-unknown-symbol))";
+        let ast = parse(text.chars(), HashSet::new());
+        assert_eq!(ast.errors().collect::<Vec<_>>(), Vec::<&Error>::new());
+    }
 }

--- a/crates/fennel-parser/src/ast.rs
+++ b/crates/fennel-parser/src/ast.rs
@@ -1220,9 +1220,29 @@ mod tests {
     }
 
     #[test]
-    fn comment_form() {
+    fn comment_form_should_suppress_errors() {
         let text = "(comment (fn f [] some-unknown-symbol))";
         let ast = parse(text.chars(), HashSet::new());
         assert_eq!(ast.errors().collect::<Vec<_>>(), Vec::<&Error>::new());
+    }
+
+    #[test]
+    fn comment_form_should_allow_keywords() {
+        let text = "(comment fn and comment are keywords)";
+        let ast = parse(text.chars(), HashSet::new());
+        assert_eq!(ast.errors().collect::<Vec<_>>(), Vec::<&Error>::new());
+    }
+
+    #[test]
+    fn comment_form_should_introduce_scope() {
+        let text = r#"
+        (comment (fn f [] some-unknown-symbol))
+        (f)
+        "#;
+        let ast = parse(text.chars(), HashSet::new());
+        assert_eq!(
+            ast.errors().map(|e| e.kind.clone()).collect::<Vec<_>>(),
+            vec![ErrorKind::Undefined]
+        );
     }
 }

--- a/crates/fennel-parser/src/ast/bind.rs
+++ b/crates/fennel-parser/src/ast/bind.rs
@@ -728,6 +728,7 @@ ast_assoc!(
         ImportMacros,
         Match, MatchTry, Catch,
         Macro, Macros,
+        CommentForm,
     ]
 );
 

--- a/crates/fennel-parser/src/ast/error.rs
+++ b/crates/fennel-parser/src/ast/error.rs
@@ -304,7 +304,19 @@ pub(crate) enum SuppressErrorKind {
     Unexpected(SyntaxKind),
 }
 
-ast_assoc!(Suppress, [MacroQuote, FuncAst]);
+ast_assoc!(Suppress, [MacroQuote, FuncAst, CommentForm]);
+
+impl CommentForm {
+    pub(crate) fn suppress(&self) -> (TextRange, Vec<SuppressErrorKind>) {
+        let range = self.syntax().text_range();
+        (range, vec![
+            SuppressErrorKind::Unused,
+            SuppressErrorKind::Unterminated,
+            SuppressErrorKind::Undefined,
+            SuppressErrorKind::AllUnexpected,
+        ])
+    }
+}
 
 impl MacroQuote {
     pub(crate) fn suppress(&self) -> (TextRange, Vec<SuppressErrorKind>) {
@@ -350,6 +362,7 @@ impl Suppress {
         match self {
             Self::MacroQuote(n) => vec![n.suppress()],
             Self::FuncAst(n) => n.suppress().unwrap_or_default(),
+            Self::CommentForm(n) => vec![n.suppress()],
         }
     }
 }

--- a/crates/fennel-parser/src/ast/nodes.rs
+++ b/crates/fennel-parser/src/ast/nodes.rs
@@ -67,6 +67,7 @@ ast_node!(Macrodebug, N_MACRODEBUG);
 ast_node!(IntoClause, N_INTO_CLAUSE);
 ast_node!(UntilClause, N_UNTIL_CLAUSE);
 ast_node!(MacroQuote, N_MACRO_QUOTE);
+ast_node!(CommentForm, N_COMMENT_FORM);
 
 ast_assoc!(BindingSymbol, [LeftSymbol, LeftRightSymbol]);
 

--- a/crates/fennel-parser/src/parser.rs
+++ b/crates/fennel-parser/src/parser.rs
@@ -249,6 +249,7 @@ impl<'p> Parser<'p> {
                             (N_ARGS ? TokenSet::R_PAREN) },
             { N_SUBLIST ::= (N_SYMBOL_CALL),
                             (N_ARGS ? TokenSet::R_PAREN) },
+            { N_SUBLIST ::= (N_COMMENT_FORM) },
             { N_SUBLIST ::= (N_VAR) },
             { N_SUBLIST ::= (N_SET) },
             { N_SUBLIST ::= (N_TSET) },
@@ -469,6 +470,9 @@ impl<'p> Parser<'p> {
 
             { N_NUMBER ::= (FLOAT) },
             { N_NUMBER ::= (INTEGER) },
+
+            { N_COMMENT_FORM ::= (KEYWORD_COMMENT),
+                       (N_BODY) },
 
             { N_DO ::= (KEYWORD_DO),
                        (N_BODY ? TokenSet::R_PAREN) },

--- a/crates/fennel-parser/src/parser/sets.rs
+++ b/crates/fennel-parser/src/parser/sets.rs
@@ -117,6 +117,7 @@ pub(crate) fn first_set(syntax: SyntaxKind, cur: SyntaxKind) -> bool {
         N_ACCUMULATE => [KEYWORD_ACCUMULATE].contains(&cur),
         N_DO => [KEYWORD_DO].contains(&cur),
         N_WHILE => [KEYWORD_WHILE].contains(&cur),
+        N_COMMENT_FORM => [KEYWORD_COMMENT].contains(&cur),
 
         N_OPERATION => [OPERATOR, KEYWORD_OR, COLON, LENGTH].contains(&cur),
 

--- a/crates/fennel-parser/src/static/keywords
+++ b/crates/fennel-parser/src/static/keywords
@@ -13,6 +13,7 @@
 "include",
 "accumulate",
 "catch",
+"comment",
 "collect",
 "icollect",
 "fcollect",

--- a/crates/fennel-parser/src/syntax.rs
+++ b/crates/fennel-parser/src/syntax.rs
@@ -70,6 +70,7 @@ pub enum SyntaxKind {
     KEYWORD_WHERE,
     KEYWORD_WHILE,
     KEYWORD_WITH_OPEN,
+    KEYWORD_COMMENT,
 
     COMMENT,
     WHITESPACE,
@@ -209,6 +210,7 @@ pub enum SyntaxKind {
     N_CATCH,
     N_CATCH_LIST,
     N_VARARG,
+    N_COMMENT_FORM,
 
     END,
     ROOT,
@@ -405,6 +407,7 @@ pub(crate) const TOEKN: &[(&str, SyntaxKind)] = &[
     ("where", SyntaxKind::KEYWORD_WHERE),
     ("while", SyntaxKind::KEYWORD_WHILE),
     ("with-open", SyntaxKind::KEYWORD_WITH_OPEN),
+    ("comment", SyntaxKind::KEYWORD_COMMENT),
 ];
 
 impl From<u16> for SyntaxKind {


### PR DESCRIPTION
Hi! Thanks for this project - I've been using it daily for a couple of weeks now and it's been incredibly helpful.

I took a stab at adding support for the `(comment ...)` special form. I was originally going to treat it the same way as syntax comments (the fennel compiler collects the body into a string, see [here](https://github.com/bakpakin/Fennel/blob/8730504bffe37bc59494b05d7489d4ebe047c76a/src/fennel/specials.fnl#L792)), but after starting I realised that in the context of a language server you might want to provide some IDE support within comments.

The usecase I have in mind is "REPL comments" that let you test code during interactive development:
```fennel
(fn my-function [x] ...)

(comment 
    (local a :a)
    (my-function a)) ;; should ideally provide completions for both `a` and `my-function`
```

Exactly how that should work is a bit unclear though. As a first draft, I ended up with something like:
- `(comment <body>)` introduces a new scope. This prevents local symbols defined inside the comment from leaking outside, but enables IDE support within the comment body. (TODO: globals may still leak)
- The comment form suppresses all errors inside the body. This is to avoid conflicts with the more general usecase, i.e. `(comment this is just a comment)`

What do you think?

Related: #1 